### PR TITLE
Do not render changelogs at/below tag 1.0.1

### DIFF
--- a/.devops/calculateChangelogs.js
+++ b/.devops/calculateChangelogs.js
@@ -69,6 +69,10 @@ function getAllTags() {
     var tags = JSON.parse(stdout);
     // Sort oldest to newest.
     semverSort.asc(tags);
+    // If a threshold is defined, drop all tags equal to or lesser than it.
+    // This is useful for when repos are migrated and PR history won't match up.
+    var threshold = process.argv[3]
+    if (threshold) tags = tags.filter(tag => semver.gt(tag, threshold))
     console.log(`Tags found (${tags.length}):\n${JSON.stringify(tags, null, 2)}`);
     // Assemble a new list of RC tags with the desired schema.
     rcTags = tags.slice(0).map(function(tag) { return {

--- a/.devops/post-release.sh
+++ b/.devops/post-release.sh
@@ -42,7 +42,7 @@ echo 'Generating changelog updates...'
 CURRENT_DIR="$(pwd)"
 cd ~ # Prevents codebase contamination.
 npm install --no-spin bluebird any-promise request-promise-any request semver semver-extra semver-sort parse-link-header > /dev/null 2>&1
-node $THIS_DIR/calculateChangelogs.js $CURRENT_DIR
+node $THIS_DIR/calculateChangelogs.js $CURRENT_DIR '1.0.1'
 eval cd $CURRENT_DIR
 # Push the changelog to GitHub.
 echo

--- a/.devops/tests.sh
+++ b/.devops/tests.sh
@@ -13,8 +13,8 @@ done
 touch key.pem
 zip key.pem.zip key.pem
 
-pip install coverage
-python setup.py install
+#pip install coverage
+#python setup.py install
 
 # This outputs the complete current python version to `pyver`
 pyver=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')

--- a/.devops/tests.sh
+++ b/.devops/tests.sh
@@ -13,9 +13,6 @@ done
 touch key.pem
 zip key.pem.zip key.pem
 
-#pip install coverage
-#python setup.py install
-
 # This outputs the complete current python version to `pyver`
 pyver=$(python -c 'import sys; print(".".join(map(str, sys.version_info[:3])))')
 echo Python $pyver


### PR DESCRIPTION
Because we migrated the repo from another org, PRs that were merged at or prior to tag 1.0.1 are not in this repo, thus resulting in empty changelog generation for those tags. This PR fixes that by skipping PR generation for those tags.

The broken test harness is also fixed in this PR.