### PR TITLE
Datapoint Send Functionality

### DIFF
--- a/auklet/broker.py
+++ b/auklet/broker.py
@@ -42,7 +42,7 @@ class MQTTClient(object):
         self.producer_types = {
             "monitoring": "python/profiler/{}".format(topic_suffix),
             "event": "python/events/{}".format(topic_suffix),
-            "send": "datapoints/{}/{}".format(topic_suffix)
+            "send": "datapoints/{}".format(topic_suffix)
         }
 
     def _write_conf(self, info):

--- a/auklet/broker.py
+++ b/auklet/broker.py
@@ -42,7 +42,7 @@ class MQTTClient(object):
         self.producer_types = {
             "monitoring": "python/profiler/{}".format(topic_suffix),
             "event": "python/events/{}".format(topic_suffix),
-            "send": self.producer_types['send'].format(topic_suffix)
+            "send": "datapoints/{}/{}".format(topic_suffix)
         }
 
     def _write_conf(self, info):

--- a/auklet/broker.py
+++ b/auklet/broker.py
@@ -30,6 +30,7 @@ class MQTTClient(object):
     producer_types = {
         "monitoring": "python/profiler/{}/{}",
         "event": "python/events/{}/{}",
+        "send": "datapoints/{}/{}"
     }
 
     def __init__(self, client):
@@ -41,6 +42,7 @@ class MQTTClient(object):
         self.producer_types = {
             "monitoring": "python/profiler/{}".format(topic_suffix),
             "event": "python/events/{}".format(topic_suffix),
+            "send": self.producer_types['send'].format(topic_suffix)
         }
 
     def _write_conf(self, info):

--- a/auklet/monitoring/__init__.py
+++ b/auklet/monitoring/__init__.py
@@ -13,6 +13,7 @@ from auklet.broker import MQTTClient
 from auklet.utils import get_mac, setup_thread_excepthook, create_dir
 from auklet.monitoring.logging import AukletLogging
 from auklet.monitoring.processing import Client
+from auklet.monitoring.utils import update_data_limits
 from auklet.stats import MonitoringTree
 from auklet.errors import AukletConfigurationError
 
@@ -60,7 +61,7 @@ class Monitoring(AukletLogging):
         self.mac_hash = get_mac()
         self.client = Client(api_key, app_id, release, base_url,
                              self.mac_hash, self.version, self.auklet_dir)
-        self.emission_rate = self.client.update_limits()
+        self.emission_rate = update_data_limits(self.client)
         self.tree = MonitoringTree(self.mac_hash)
         self.broker = MQTTClient(self.client)
         self.monitor = monitoring
@@ -107,7 +108,7 @@ class Monitoring(AukletLogging):
             self.tree.clear_root()
             self.samples_taken = 0
         if self.total_samples % self.hour == 0:
-            self.emission_rate = self.client.update_limits()
+            self.emission_rate = update_data_limits(self.client)
             self.client.check_date()
 
     def handle_exc(self, type, value, traceback):

--- a/auklet/monitoring/__init__.py
+++ b/auklet/monitoring/__init__.py
@@ -118,7 +118,7 @@ class Monitoring(AukletLogging):
 
     def send(self, msg):
         self.broker.produce(
-            self.client.build_msgpack_send_data(msg, "send"), "send"
+            self.client.build_msgpack_send_data(msg), "send"
         )
 
     def log(self, msg, data_type, level="INFO"):

--- a/auklet/monitoring/__init__.py
+++ b/auklet/monitoring/__init__.py
@@ -116,6 +116,11 @@ class Monitoring(AukletLogging):
                 type, traceback, self.tree), "event")
         sys.__excepthook__(type, value, traceback)
 
+    def send(self, msg):
+        self.broker.produce(
+            self.client.build_msgpack_send_data(msg, "send"), "send"
+        )
+
     def log(self, msg, data_type, level="INFO"):
         self.broker.produce(
             self.client.build_msgpack_log_data(msg, data_type, level), "event")

--- a/auklet/monitoring/__init__.py
+++ b/auklet/monitoring/__init__.py
@@ -116,9 +116,9 @@ class Monitoring(AukletLogging):
                 type, traceback, self.tree), "event")
         sys.__excepthook__(type, value, traceback)
 
-    def send(self, msg):
+    def send(self, msg, data_type="motion"):
         self.broker.produce(
-            self.client.build_msgpack_send_data(msg), "send"
+            self.client.build_msgpack_send_data(msg, data_type), "send"
         )
 
     def log(self, msg, data_type, level="INFO"):

--- a/auklet/monitoring/processing.py
+++ b/auklet/monitoring/processing.py
@@ -259,7 +259,7 @@ class Client(object):
         }
         return log_dict
 
-    def build_send_data(self, msg):
+    def build_send_data(self, msg, data_type):
         send_dict = {
             "payload": msg,
             "application": self.app_id,
@@ -270,7 +270,8 @@ class Client(object):
             "release": self.commit_hash,
             "agentVersion": get_agent_version(),
             "device": self.broker_username,
-            "version": self.version
+            "version": self.version,
+            "type": data_type
         }
         return send_dict
 
@@ -282,6 +283,6 @@ class Client(object):
         log_data = self.build_log_data(msg, data_type, level)
         return msgpack.packb(log_data, use_bin_type=False)
 
-    def build_msgpack_send_data(self, msg):
-        send_data = self.build_send_data(msg)
+    def build_msgpack_send_data(self, msg, data_type):
+        send_data = self.build_send_data(msg, data_type)
         return msgpack.packb(send_data, use_bin_type=False)

--- a/auklet/monitoring/processing.py
+++ b/auklet/monitoring/processing.py
@@ -259,6 +259,21 @@ class Client(object):
         }
         return log_dict
 
+    def build_send_data(self, msg):
+        send_dict = {
+            "payload": msg,
+            "application": self.app_id,
+            "publicIP": get_device_ip(),
+            "id": str(uuid4()),
+            "timestamp": int(round(time() * 1000)),
+            "macAddressHash": self.mac_hash,
+            "release": self.commit_hash,
+            "agentVersion": get_agent_version(),
+            "device": self.broker_username,
+            "version": self.version
+        }
+        return send_dict
+
     def build_msgpack_event_data(self, type, tb, tree):
         event_data = self.build_event_data(type, tb, tree)
         return msgpack.packb(event_data, use_bin_type=False)
@@ -266,3 +281,7 @@ class Client(object):
     def build_msgpack_log_data(self, msg, data_type, level):
         log_data = self.build_log_data(msg, data_type, level)
         return msgpack.packb(log_data, use_bin_type=False)
+
+    def build_msgpack_send_data(self, msg):
+        send_data = self.build_send_data(msg)
+        return msgpack.packb(send_data, use_bin_type=False)

--- a/auklet/monitoring/processing.py
+++ b/auklet/monitoring/processing.py
@@ -1,14 +1,13 @@
 import json
 import msgpack
-import traceback
 
-from time import time
-from uuid import uuid4
 from datetime import datetime
-from auklet.stats import Event, SystemMetrics
-from auklet.utils import create_file, \
-    get_abs_path, get_device_ip, open_auklet_url, build_url, \
-    get_agent_version, post_auklet_url, u
+from auklet.stats import SystemMetrics
+from auklet.utils import (create_file, get_abs_path, open_auklet_url,
+                          build_url, post_auklet_url, u)
+from auklet.monitoring.utils import (load_limits, check_data_limits,
+                                     update_data_limits, build_send_data,
+                                     build_log_data, build_event_data)
 
 try:
     # For Python 3.0 and later
@@ -61,7 +60,7 @@ class Client(object):
         self.version = version
         self.auklet_dir = auklet_dir
         self._set_filenames()
-        self._load_limits()
+        load_limits(self)
         create_file(self.offline_filename)
         create_file(self.limits_filename)
         create_file(self.usage_filename)
@@ -141,28 +140,6 @@ class Client(object):
         if res is not None:
             return json.loads(u(res.read()))['config']
 
-    def _load_limits(self):
-        try:
-            with open(self.limits_filename, "r") as limits:
-                limits_str = limits.read()
-                if limits_str:
-                    data = json.loads(limits_str)
-                    self.data_day = data['data']['normalized_cell_plan_date']
-                    temp_limit = data['data']['cellular_data_limit']
-                    if temp_limit is not None:
-                        self.data_limit = data['data'][
-                                              'cellular_data_limit'] * MB_TO_B
-                    else:
-                        self.data_limit = temp_limit
-                    temp_offline = data['storage']['storage_limit']
-                    if temp_offline is not None:
-                        self.offline_limit = data['storage'][
-                                                 'storage_limit'] * MB_TO_B
-                    else:
-                        self.offline_limit = data['storage']['storage_limit']
-        except IOError:
-            return
-
     def _build_usage_json(self):
         return {"data": self.data_current, "offline": self.offline_current}
 
@@ -174,20 +151,7 @@ class Client(object):
             return False
 
     def check_data_limit(self, data, current_use, offline=False):
-        if self.offline_limit is None and offline:
-            return True
-        if self.data_limit is None and not offline:
-            return True
-        data_size = len(data)
-        temp_current = current_use + data_size
-        if temp_current >= self.data_limit:
-            return False
-        if offline:
-            self.offline_current = temp_current
-        else:
-            self.data_current = temp_current
-        self._update_usage_file()
-        return True
+        return check_data_limits(self, data, current_use, offline)
 
     def check_date(self):
         if datetime.today().day == self.data_day:
@@ -197,92 +161,14 @@ class Client(object):
         else:
             self.reset_data = True
 
-    def update_limits(self):
-        config = self._get_config()
-        if config is None:
-            return 60000
-        with open(self.limits_filename, 'w+') as limits:
-            limits.truncate()
-            limits.write(json.dumps(config))
-        new_day = config['data']['normalized_cell_plan_date']
-        temp_limit = config['data']['cellular_data_limit']
-        if temp_limit is not None:
-            new_data = config['data']['cellular_data_limit'] * MB_TO_B
-        else:
-            new_data = temp_limit
-        temp_offline = config['storage']['storage_limit']
-        if temp_offline is not None:
-            new_offline = config['storage']['storage_limit'] * MB_TO_B
-        else:
-            new_offline = config['storage']['storage_limit']
-        if self.data_day != new_day:
-            self.data_day = new_day
-            self.data_current = 0
-        if self.data_limit != new_data:
-            self.data_limit = new_data
-        if self.offline_limit != new_offline:
-            self.offline_limit = new_offline
-        # return emission period in ms
-        return config['emission_period'] * S_TO_MS
-
-    def build_event_data(self, type, tb, tree):
-        event = Event(type, tb, tree, self.abs_path)
-        event_dict = dict(event)
-        event_dict['application'] = self.app_id
-        event_dict['publicIP'] = get_device_ip()
-        event_dict['id'] = str(uuid4())
-        event_dict['timestamp'] = int(round(time() * 1000))
-        event_dict['systemMetrics'] = dict(self.system_metrics)
-        event_dict['macAddressHash'] = self.mac_hash
-        event_dict['release'] = self.commit_hash
-        event_dict['agentVersion'] = get_agent_version()
-        event_dict['device'] = self.broker_username
-        event_dict['absPath'] = self.abs_path
-        event_dict['version'] = self.version
-        return event_dict
-
-    def build_log_data(self, msg, data_type, level):
-        log_dict = {
-            "message": msg,
-            "type": data_type,
-            "level": level,
-            "application": self.app_id,
-            "publicIP": get_device_ip(),
-            "id": str(uuid4()),
-            "timestamp": int(round(time() * 1000)),
-            "systemMetrics": dict(self.system_metrics),
-            "macAddressHash": self.mac_hash,
-            "release": self.commit_hash,
-            "agentVersion": get_agent_version(),
-            "device": self.broker_username,
-            "version": self.version
-        }
-        return log_dict
-
-    def build_send_data(self, msg, data_type):
-        send_dict = {
-            "payload": msg,
-            "application": self.app_id,
-            "publicIP": get_device_ip(),
-            "id": str(uuid4()),
-            "timestamp": int(round(time() * 1000)),
-            "macAddressHash": self.mac_hash,
-            "release": self.commit_hash,
-            "agentVersion": get_agent_version(),
-            "device": self.broker_username,
-            "version": self.version,
-            "type": data_type
-        }
-        return send_dict
-
     def build_msgpack_event_data(self, type, tb, tree):
-        event_data = self.build_event_data(type, tb, tree)
-        return msgpack.packb(event_data, use_bin_type=False)
+        return msgpack.packb(build_event_data(self, type, tb, tree),
+                             use_bin_type=False)
 
     def build_msgpack_log_data(self, msg, data_type, level):
-        log_data = self.build_log_data(msg, data_type, level)
-        return msgpack.packb(log_data, use_bin_type=False)
+        return msgpack.packb(build_log_data(self, msg, data_type, level),
+                             use_bin_type=False)
 
     def build_msgpack_send_data(self, msg, data_type):
-        send_data = self.build_send_data(msg, data_type)
-        return msgpack.packb(send_data, use_bin_type=False)
+        return msgpack.packb(build_send_data(self, msg, data_type),
+                             use_bin_type=False)

--- a/auklet/monitoring/processing.py
+++ b/auklet/monitoring/processing.py
@@ -6,7 +6,7 @@ from auklet.stats import SystemMetrics
 from auklet.utils import (create_file, get_abs_path, open_auklet_url,
                           build_url, post_auklet_url, u)
 from auklet.monitoring.utils import (load_limits, check_data_limits,
-                                     update_data_limits, build_send_data,
+                                     build_send_data,
                                      build_log_data, build_event_data)
 
 try:

--- a/auklet/monitoring/utils.py
+++ b/auklet/monitoring/utils.py
@@ -1,0 +1,133 @@
+import json
+import traceback
+from time import time
+from uuid import uuid4
+
+from auklet.stats import Event
+from auklet.utils import get_agent_version, get_device_ip
+
+MB_TO_B = 1e6
+S_TO_MS = 1000
+
+
+def load_limits(client):
+    try:
+        with open(client.limits_filename, "r") as limits:
+            limits_str = limits.read()
+            if limits_str:
+                data = json.loads(limits_str)
+                client.data_day = data['data']['normalized_cell_plan_date']
+                temp_limit = data['data']['cellular_data_limit']
+                if temp_limit is not None:
+                    client.data_limit = data['data'][
+                                          'cellular_data_limit'] * MB_TO_B
+                else:
+                    client.data_limit = temp_limit
+                temp_offline = data['storage']['storage_limit']
+                if temp_offline is not None:
+                    client.offline_limit = data['storage'][
+                                             'storage_limit'] * MB_TO_B
+                else:
+                    client.offline_limit = data['storage']['storage_limit']
+    except IOError:
+        return
+
+
+def check_data_limits(client, data, current_use, offline=False):
+    if client.offline_limit is None and offline:
+        return True
+    if client.data_limit is None and not offline:
+        return True
+    data_size = len(data)
+    temp_current = current_use + data_size
+    if temp_current >= client.data_limit:
+        return False
+    if offline:
+        client.offline_current = temp_current
+    else:
+        client.data_current = temp_current
+        client._update_usage_file()
+    return True
+
+
+def update_data_limits(client):
+    config = client._get_config()
+    if config is None:
+        return 60000
+    with open(client.limits_filename, 'w+') as limits:
+        limits.truncate()
+        limits.write(json.dumps(config))
+    new_day = config['data']['normalized_cell_plan_date']
+    temp_limit = config['data']['cellular_data_limit']
+    if temp_limit is not None:
+        new_data = config['data']['cellular_data_limit'] * MB_TO_B
+    else:
+        new_data = temp_limit
+    temp_offline = config['storage']['storage_limit']
+    if temp_offline is not None:
+        new_offline = config['storage']['storage_limit'] * MB_TO_B
+    else:
+        new_offline = config['storage']['storage_limit']
+    if client.data_day != new_day:
+        client.data_day = new_day
+        client.data_current = 0
+    if client.data_limit != new_data:
+        client.data_limit = new_data
+    if client.offline_limit != new_offline:
+        client.offline_limit = new_offline
+    # return emission period in ms
+    return config['emission_period'] * S_TO_MS
+
+
+def build_event_data(client, type, tb, tree):
+    event = Event(type, tb, tree, client.abs_path)
+    event_dict = dict(event)
+    event_dict['application'] = client.app_id
+    event_dict['publicIP'] = get_device_ip()
+    event_dict['id'] = str(uuid4())
+    event_dict['timestamp'] = int(round(time() * 1000))
+    event_dict['systemMetrics'] = dict(client.system_metrics)
+    event_dict['macAddressHash'] = client.mac_hash
+    event_dict['release'] = client.commit_hash
+    event_dict['agentVersion'] = get_agent_version()
+    event_dict['device'] = client.broker_username
+    event_dict['absPath'] = client.abs_path
+    event_dict['version'] = client.version
+    return event_dict
+
+
+def build_log_data(client, msg, data_type, level):
+    log_dict = {
+        "message": msg,
+        "type": data_type,
+        "level": level,
+        "application": client.app_id,
+        "publicIP": get_device_ip(),
+        "id": str(uuid4()),
+        "timestamp": int(round(time() * 1000)),
+        "systemMetrics": dict(client.system_metrics),
+        "macAddressHash": client.mac_hash,
+        "release": client.commit_hash,
+        "agentVersion": get_agent_version(),
+        "device": client.broker_username,
+        "version": client.version
+    }
+    return log_dict
+
+
+def build_send_data(client, msg, data_type):
+    send_dict = {
+        "payload": msg,
+        "application": client.app_id,
+        "publicIP": get_device_ip(),
+        "id": str(uuid4()),
+        "timestamp": int(round(time() * 1000)),
+        "macAddressHash": client.mac_hash,
+        "release": client.commit_hash,
+        "agentVersion": get_agent_version(),
+        "device": client.broker_username,
+        "version": client.version,
+        "type": data_type
+    }
+    return send_dict
+

--- a/auklet/monitoring/utils.py
+++ b/auklet/monitoring/utils.py
@@ -17,18 +17,13 @@ def load_limits(client):
             if limits_str:
                 data = json.loads(limits_str)
                 client.data_day = data['data']['normalized_cell_plan_date']
-                temp_limit = data['data']['cellular_data_limit']
-                if temp_limit is not None:
-                    client.data_limit = data['data'][
-                                          'cellular_data_limit'] * MB_TO_B
-                else:
-                    client.data_limit = temp_limit
-                temp_offline = data['storage']['storage_limit']
-                if temp_offline is not None:
-                    client.offline_limit = data['storage'][
-                                             'storage_limit'] * MB_TO_B
-                else:
-                    client.offline_limit = data['storage']['storage_limit']
+                client.data_limit = data['data']['cellular_data_limit']
+                if client.data_limit is not None:
+                    client.data_limit *= MB_TO_B
+
+                client.offline_limit = data['storage']['storage_limit']
+                if client.offline_limit is not None:
+                    client.offline_limit *= MB_TO_B
     except IOError:
         return
 
@@ -57,24 +52,17 @@ def update_data_limits(client):
     with open(client.limits_filename, 'w+') as limits:
         limits.truncate()
         limits.write(json.dumps(config))
-    new_day = config['data']['normalized_cell_plan_date']
-    temp_limit = config['data']['cellular_data_limit']
-    if temp_limit is not None:
-        new_data = config['data']['cellular_data_limit'] * MB_TO_B
-    else:
-        new_data = temp_limit
-    temp_offline = config['storage']['storage_limit']
-    if temp_offline is not None:
-        new_offline = config['storage']['storage_limit'] * MB_TO_B
-    else:
-        new_offline = config['storage']['storage_limit']
-    if client.data_day != new_day:
-        client.data_day = new_day
+    client.data_limit = config['data']['cellular_data_limit']
+    if client.data_limit is not None:
+        client.data_limit *= MB_TO_B
+
+    client.offline_limit = config['storage']['storage_limit']
+    if client.offline_limit is not None:
+        client.offline_limit *= MB_TO_B
+
+    if client.data_day != config['data']['normalized_cell_plan_date']:
+        client.data_day = config['data']['normalized_cell_plan_date']
         client.data_current = 0
-    if client.data_limit != new_data:
-        client.data_limit = new_data
-    if client.offline_limit != new_offline:
-        client.offline_limit = new_offline
     # return emission period in ms
     return config['emission_period'] * S_TO_MS
 

--- a/src/benchmark/run_tests.py
+++ b/src/benchmark/run_tests.py
@@ -15,7 +15,7 @@ def without_auklet():
     base.start(state="WithoutAuklet")
 
 
-@patch('auklet.monitoring.processing.Client.update_limits')
+@patch('auklet.monitoring.utils.update_data_limits')
 @patch('auklet.broker.MQTTClient._get_certs')
 def with_auklet_and_mqtt(get_certs_mock, update_limits_mock):
     """

--- a/src/benchmark/run_tests.py
+++ b/src/benchmark/run_tests.py
@@ -15,7 +15,7 @@ def without_auklet():
     base.start(state="WithoutAuklet")
 
 
-@patch('auklet.monitoring.utils.update_data_limits')
+@patch('auklet.monitoring.update_data_limits')
 @patch('auklet.broker.MQTTClient._get_certs')
 def with_auklet_and_mqtt(get_certs_mock, update_limits_mock):
     """

--- a/tests/test___init__.py
+++ b/tests/test___init__.py
@@ -93,6 +93,12 @@ class TestMonitoring(unittest.TestCase):
             self.monitoring.log("", "")
             self.assertIsNotNone(test_log_data)
 
+    def test_send(self):
+        with patch('auklet.broker.MQTTClient.produce') as _produce:
+            _produce.side_effect = self.produce
+            self.monitoring.send({"latitude": 0.0, "longitude": 0.0},
+                                 data_type="location")
+
     def build_msgpack_tree(self, app_id):
         print(app_id)
 
@@ -103,6 +109,11 @@ class TestMonitoring(unittest.TestCase):
     def produce(data, data_type):
         global test_log_data
         test_log_data = data
+
+    @staticmethod
+    def send_produce(data, data_type):
+        global test_send_data
+        test_send_data = data
 
     @staticmethod
     def get_conf():

--- a/tests/test_broker.py
+++ b/tests/test_broker.py
@@ -106,7 +106,7 @@ class TestMQTTBroker(unittest.TestCase):
         def tls_set(self, ca_certs):
             pass
 
-        def tls_set_context(self):
+        def tls_set_context(self, context):
             pass
 
         def connect_async(self, broker, port):

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -11,6 +11,7 @@ from tests import data_factory
 from auklet.utils import b
 from auklet.stats import MonitoringTree
 from auklet.monitoring.processing import Client
+from auklet.monitoring.utils import update_data_limits, load_limits
 
 try:
     # For Python 3.0 and later
@@ -105,13 +106,13 @@ class TestClient(unittest.TestCase):
 
         data = data_factory.LimitsGenerator(cellular_data_limit=10)
         self.write_load_limits_test(data)
-        self.client._load_limits()
+        load_limits(self.client)
         self.build_load_limits_test(10000000.0, self.client.data_limit)
 
         data = data_factory.LimitsGenerator(
             cellular_data_limit="null", storage_limit=10)
         self.write_load_limits_test(data)
-        self.client._load_limits()
+        load_limits(self.client)
         self.build_load_limits_test(10000000.0, self.client.offline_limit)
 
         with open(self.client.limits_filename, "w") as limits:
@@ -119,7 +120,7 @@ class TestClient(unittest.TestCase):
 
         self.base_patch_side_effect_with_none(
             'auklet.monitoring.processing.open',
-            IOError, self.client._load_limits)
+            IOError, load_limits, self.client)
 
     def test_build_usage_json(self):
         data = self.client._build_usage_json()
@@ -174,44 +175,28 @@ class TestClient(unittest.TestCase):
         with patch(
                 'auklet.monitoring.processing.Client._get_config',
                 new=self._get_config):
-            self.assertEqual(self.client.update_limits(), 60000)
+            self.assertEqual(update_data_limits(self.client), 60000)
             self.none = False
 
             self.cellular_data_limit = 1000
-            self.client.update_limits()
+            update_data_limits(self.client)
             self.assertEqual(self.client.data_limit, 1000000000.0)
             self.cellular_data_limit = None
 
             self.storage_limit = 1000
-            self.client.update_limits()
+            update_data_limits(self.client)
             self.assertEqual(self.client.offline_limit, 1000000000.0)
             self.storage_limit = None
 
             self.cell_plan_date = 10
-            self.client.update_limits()
+            update_data_limits(self.client)
             self.assertEqual(self.client.data_day, 10)
             self.cell_plan_date = 1
 
-            self.assertEqual(self.client.update_limits(), 60000)
-
-    def test_build_event_data(self):
-        with patch("auklet.monitoring.processing.traceback.format_exc",
-                   new=self.mock_format_exc):
-            self.assertBuildEventData(self.client.build_event_data)
-
-    def test_build_send_data(self):
-        self.assertIsNotNone(
-            self.client.build_send_data(
-                {"latitude": 0.0, "longitude": 0.0},
-                data_type="location"))
-
-    def test_build_log_data(self):
-        self.assertBuildLogData(
-            self.client.build_log_data(
-                msg='msg', data_type='data_type', level='level'))
+            self.assertEqual(update_data_limits(self.client), 60000)
 
     def test_build_msgpack_event_data(self):
-        with patch("auklet.monitoring.processing.traceback.format_exc",
+        with patch("auklet.monitoring.utils.traceback.format_exc",
                    new=self.mock_format_exc):
             self.assertBuildEventData(self.client.build_msgpack_event_data)
 
@@ -239,10 +224,14 @@ class TestClient(unittest.TestCase):
                   "locals":
                     {"key": "value"}}]}
 
-    def base_patch_side_effect_with_none(self, location, side_effect, actual):
+    def base_patch_side_effect_with_none(self, location, side_effect, actual,
+                                         arg=None):
         with patch(location) as _base:
             _base.side_effect = side_effect
-            self.assertIsNone(actual())
+            if arg is not None:
+                self.assertIsNone(actual(arg))
+            else:
+                self.assertIsNone(actual())
 
     def build_load_limits_test(self, expected, actual):
         self.assertEqual(expected, actual)
@@ -270,7 +259,7 @@ class TestClient(unittest.TestCase):
             return Traceback
 
         with patch(
-                'auklet.monitoring.processing.Event', new=self.get_mock_event):
+                'auklet.monitoring.utils.Event', new=self.get_mock_event):
             self.monitoring_tree.cached_filenames["file_name"] = "file_name"
             self.assertNotEqual(
                 function(
@@ -308,7 +297,6 @@ class TestClient(unittest.TestCase):
     class MockResult(object):
         def read(self):
             return b(json.dumps({"test": "object"}))
-
 
 
 if __name__ == '__main__':

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -120,7 +120,7 @@ class TestClient(unittest.TestCase):
 
         self.base_patch_side_effect_with_none(
             'auklet.monitoring.processing.open',
-            IOError, load_limits, self.client)
+            IOError, (load_limits, self.client))
 
     def test_build_usage_json(self):
         data = self.client._build_usage_json()
@@ -224,14 +224,15 @@ class TestClient(unittest.TestCase):
                   "locals":
                     {"key": "value"}}]}
 
-    def base_patch_side_effect_with_none(self, location, side_effect, actual,
-                                         arg=None):
+    def base_patch_side_effect_with_none(self, location, side_effect,
+                                         func_info):
+        func, arg = func_info
         with patch(location) as _base:
             _base.side_effect = side_effect
             if arg is not None:
-                self.assertIsNone(actual(arg))
+                self.assertIsNone(func(arg))
             else:
-                self.assertIsNone(actual())
+                self.assertIsNone(func())
 
     def build_load_limits_test(self, expected, actual):
         self.assertEqual(expected, actual)

--- a/tests/test_processing.py
+++ b/tests/test_processing.py
@@ -199,6 +199,12 @@ class TestClient(unittest.TestCase):
                    new=self.mock_format_exc):
             self.assertBuildEventData(self.client.build_event_data)
 
+    def test_build_send_data(self):
+        self.assertIsNotNone(
+            self.client.build_send_data(
+                {"latitude": 0.0, "longitude": 0.0},
+                data_type="location"))
+
     def test_build_log_data(self):
         self.assertBuildLogData(
             self.client.build_log_data(
@@ -208,6 +214,13 @@ class TestClient(unittest.TestCase):
         with patch("auklet.monitoring.processing.traceback.format_exc",
                    new=self.mock_format_exc):
             self.assertBuildEventData(self.client.build_msgpack_event_data)
+
+    def test_build_msgpack_send_data(self):
+        self.assertIsNotNone(
+            self.client.build_msgpack_send_data(
+                {"latitude": 0.0, "longitude": 0.0},
+                data_type="location")
+        )
 
     def test_build_msgpack_log_data(self):
         self.assertBuildLogData(


### PR DESCRIPTION
Allow production to `datapoints` topics via the `monitoring.send()` functionality.

